### PR TITLE
add syntax from vim-sqlx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Run current dataform model assertions
 - Run entire dataform project
 - Run dataform specific tag
+- Syntax highlighting for both sql and javascript blocks
 
 ## 📜 Requirements
 
@@ -58,6 +59,11 @@ And also every time that you edit your `.sqlx` file, and hit `:w` it will recomp
 
 🔮 It's recommended to use these commands encapsulated in some custom keymaps to make it more convenient. Choose what suits you best.
 ## 📖 Syntax Highlight
+From a syntax perspective sqlx acts like a combination of `sql` and `js` and the aim of this project is to support both syntaxes in parody with how [Dataform](https://github.com/dataform-co/dataform) uses them, more precisely:
+
+- The javascript supported by NodeJs
+- The sql supported by BigQuery
+
 ✨ Still under development...
 ## 🏰 How to contribute
 To know more on how to contribute please check our [Contributing Guide](https://github.com/magal1337/dataform.nvim/blob/main/CONTRIBUTING.md)

--- a/syntax/sql/sqlx_base.vim
+++ b/syntax/sql/sqlx_base.vim
@@ -1,0 +1,108 @@
+" Vim syntax file
+" Language: SQLX
+" Maintainer: Andres Lowrie
+" Repository: https://github.com/andres-lowrie/vim-sqlx
+" License: VIM
+" Credits: https://github.com/vim/vim/blob/master/runtime/syntax/sqloracle.vim
+
+
+" The 'Basic' sql keywords.
+"
+" This list comes from
+" https://www.postgresql.org/docs/13/sql-keywords-appendix.html since I have
+" no idea how to see the ANSI standard... chances are there are too many words
+" here
+
+syn keyword sqlxSqlSpecial false null true
+
+
+" Keywords
+" ---------------------
+syn keyword sqlxSqlKeyword allocate are array as asc asensitive asymetric atomic authorization
+syn keyword sqlxSqlKeyword begin begin_frame begin_partition blob both by
+syn keyword sqlxSqlKeyword call called cardinality cascaded case cast character_length check classifier close cluster collate column commit corresponding cross current current_catalog current_default_transform_group current_path current_row current_transform_group_for_type cursor cycle
+syn keyword sqlxSqlKeyword datalink day deallocate dec declare default define deref desc describe deterministic disconnect dlnewcopy dlpreviouscopy dlurlcomplete dlcurlcompleteonly clurlcompletewrite dlurlpath dlurlpathonly dlurlpathwrite dlurlserver dynamic
+syn keyword sqlxSqlKeyword each element else empty end end-exec end_frame
+syn keyword sqlxSqlKeyword end_partition equals every except exec execute exp
+syn keyword sqlxSqlKeyword fetch filter first_value for foreign frame_row free freeze full function fusion
+syn keyword sqlxSqlKeyword get global group grouping groups
+syn keyword sqlxSqlKeyword having hold
+syn keyword sqlxSqlKeyword identity import index indicator initial inner inout insensitive interval into
+syn keyword sqlxSqlKeyword join
+syn keyword sqlxSqlKeyword lag language large lead leading left local
+syn keyword sqlxSqlKeyword materialized measures member merge method modifies module month multiset
+syn keyword sqlxSqlKeyword natrual new no none not null nullif
+syn keyword sqlxSqlKeyword of offset old on only order outer over overlaps overlay
+syn keyword sqlxSqlKeyword parameter partition period primary procedure ptf
+syn keyword sqlxSqlKeyword rank reads recursive ref references relase result return returns right
+syn keyword sqlxSqlKeyword rollup row rows running
+syn keyword sqlxSqlKeyword scope scroll show start
+syn keyword sqlxSqlKeyword table then to trigger
+syn keyword sqlxSqlKeyword unique unnest using user
+syn keyword sqlxSqlKeyword values view
+syn keyword sqlxSqlKeyword when whenever where window with
+
+
+" Types
+" ---------------------
+syn keyword sqlxSqlType bigint binary bit blob boolean
+syn keyword sqlxSqlType char character clob date datetime dec decfloat decimal double
+syn keyword sqlxSqlType float
+syn keyword sqlxSqlType int integer
+syn keyword sqlxSqlType json
+syn keyword sqlxSqlType long
+syn keyword sqlxSqlType national nchar nclob nullable number numeric
+syn keyword sqlxSqlType precision
+syn keyword sqlxSqlType real
+syn keyword sqlxSqlType smallint
+syn keyword sqlxSqlType timestamp
+syn keyword sqlxSqlType varchar varray
+
+
+" Functions
+" ---------------------
+syn keyword sqlxSqlFunction abs acos array_agg array_max_cardinality asin atan avg
+syn keyword sqlxSqlFunction ceil ceiling char_length coalesce collect convert corr cos cosh count covar_pop covar_samp cume_dist current_date current_date current_role current_schema current_time current_timestamp current_user date
+syn keyword sqlxSqlFunction dense_rank
+syn keyword sqlxSqlFunction floor
+syn keyword sqlxSqlFunction json json_array json_arrayagg json_exists json_object json_objectagg json_query json_table json_table_primitive json_value
+syn keyword sqlxSqlFunction last_value least like_regex listagg ln localtime localtimestamp log log10 lower
+syn keyword sqlxSqlFunction match matches match_number match_recognize max min mod
+syn keyword sqlxSqlFunction normalize normalized nth_value ntile
+syn keyword sqlxSqlFunction occurrences_regex octet_length one open
+syn keyword sqlxSqlFunction percent percentile_cont percentile_desc percent_rank portion position position_regex power precedes
+syn keyword sqlxSqlFunction range regr_avgx regr_avgy regr_count regr_intercept regr_r2 regr_slope regr_sxx regr_sxy regr_syy row_count row_number
+syn keyword sqlxSqlFunction search seek session_user sin sinh sqrt stddev_pop stddev_samp substring substring_regex sum
+syn keyword sqlxSqlFunction tan timezone_hour timezone_minute translate translate_regex treat trim trim_array
+syn keyword sqlxSqlFunction var_pop var_samp
+syn keyword sqlxSqlFunction xmlagg xmlattributes xmlcast xmlbinary xmlcomment xmlconcat xmldocument xmlelement xmlexists xmlforest xmliterate xmlnamespaces xmlexists xmlforest xmliterate xmlnamespaces xmlparse xmlpi xmlquery xmlserialize xmltable xmltext xmlvalidate
+
+
+" Statements
+" ---------------------
+syn keyword sqlxSqlStatement alter
+syn keyword sqlxSqlStatement commit create
+syn keyword sqlxSqlStatement delete drop
+syn keyword sqlxSqlStatement from
+syn keyword sqlxSqlStatement grant
+syn keyword sqlxSqlStatement insert
+syn keyword sqlxSqlStatement revoke rename rollback
+syn keyword sqlxSqlStatement savepoint select set
+syn keyword sqlxSqlStatement select
+syn keyword sqlxSqlStatement truncate
+syn keyword sqlxSqlStatement update
+
+
+" Operators
+" ---------------------
+syn keyword sqlxSqlOperator all and any
+syn keyword sqlxSqlOperator between
+syn keyword sqlxSqlOperator distinct
+syn keyword sqlxSqlOperator escape exists
+syn keyword sqlxSqlOperator in intersect intersection is isnull
+syn keyword sqlxSqlOperator like
+syn keyword sqlxSqlOperator minus
+syn keyword sqlxSqlOperator prior
+syn keyword sqlxSqlOperator some sysdate
+syn keyword sqlxSqlOperator or out
+syn keyword sqlxSqlOperator union

--- a/syntax/sql/sqlx_base.vim
+++ b/syntax/sql/sqlx_base.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: SQLX
 " Maintainer: Andres Lowrie
-" Repository: https://github.com/andres-lowrie/vim-sqlx
+" Repository: https://github.com/magal1337/dataform.nvim
 " License: VIM
 " Credits: https://github.com/vim/vim/blob/master/runtime/syntax/sqloracle.vim
 

--- a/syntax/sql/sqlx_bigquery.vim
+++ b/syntax/sql/sqlx_bigquery.vim
@@ -1,0 +1,111 @@
+" Vim syntax file
+" Language: SQLX
+" Maintainer: Andres Lowrie
+" Repository: https://github.com/andres-lowrie/vim-sqlx
+" License: MIT
+
+" BigQuery Syntax
+" https://cloud.google.com/bigquery/docs/reference/standard-sql
+
+syn keyword sqlxSqlSpecial false null true
+syn keyword sqlxSqlSpecial error
+
+" Keywords
+" ---------------------
+syn keyword sqlxSqlKeyword as asc
+syn keyword sqlxSqlKeyword begin by
+syn keyword sqlxSqlKeyword coalesce cross
+syn keyword sqlxSqlKeyword desc
+syn keyword sqlxSqlKeyword for full function
+syn keyword sqlxSqlKeyword if ifnull inner
+syn keyword sqlxSqlKeyword join
+syn keyword sqlxSqlKeyword left limit
+syn keyword sqlxSqlKeyword not null nullable nullif
+syn keyword sqlxSqlKeyword of offset order outer
+syn keyword sqlxSqlKeyword partition
+syn keyword sqlxSqlKeyword safe
+syn keyword sqlxSqlKeyword right
+syn keyword sqlxSqlKeyword table
+syn keyword sqlxSqlKeyword unique unnest using
+syn keyword sqlxSqlKeyword values view
+syn keyword sqlxSqlKeyword when where with
+
+
+" Types
+" ---------------------
+syn keyword sqlxSqlType array
+syn keyword sqlxSqlType bool bytes bigdecimal bignumeric
+syn keyword sqlxSqlType date datetime decimal
+syn keyword sqlxSqlType float64
+syn keyword sqlxSqlType geography
+syn keyword sqlxSqlType int64
+syn keyword sqlxSqlType numeric
+syn keyword sqlxSqlType string struct
+syn keyword sqlxSqlType time timestamp
+
+
+" Functions
+" ---------------------
+syn keyword sqlxSqlFunction abs acos acosh any_value approx_count_distinct approx_quantiles approx_top_count approx_top_sum array_concat_agg array_reverse array_value asin asinh atan atanh atan2 ascii avg
+syn keyword sqlxSqlFunction bit_and bit_count bit_or bit_xor byte_length
+syn keyword sqlxSqlFunction cast ceil celing count countif cos cosh corr covar_pop covar_samp current_date current_datetime current_timestamp char_length character_length
+syn keyword sqlxSqlFunction chr code_points_to_bytes code_points_to_string concat cume_dist
+syn keyword sqlxSqlFunction date date_add date_sub date_diff date_trunc date_from_unix_date datetime datetime_add datetime_diff datetime_sub datetime_tunc format_datetime
+syn keyword sqlxSqlFunction div dense_rank
+syn keyword sqlxSqlFunction ends_with extract external_query exp
+syn keyword sqlxSqlFunction farm_fingerprint floor format format_date format_time format_timestamp first_value from_base32 from_base64 from_hex
+syn keyword sqlxSqlFunction generate_array generate_date_array generate_timestamp_array generate_uuid greatest
+syn keyword sqlxSqlFunction hll_count.init hll_count.merge hll_count.merge_partial hll_count.extract
+syn keyword sqlxSqlFunction left length lpad lower ltrim
+syn keyword sqlxSqlFunction ieee_divide initcap instr is_inf is_nan
+syn keyword sqlxSqlFunction json_extract json_query json_query json_extract_scalar json_value json_extract_array json_extract_string_array json_value_array
+syn keyword sqlxSqlFunction lag last_day last_value lead least ln log log10 logical_and logical_or
+syn keyword sqlxSqlFunction nth_value net.ip_from_string net.safe_ip_from_string net.ip_to_string net.ip_net_mask net.ip_trunc net.ipv4_from_int64 net.ipv4_to_int64
+syn keyword sqlxSqlFunction net.host net.public_suffix net.reg_domain ntile normalize normalize_and_casefold
+syn keyword sqlxSqlFunction max md5 min mod
+syn keyword sqlxSqlFunction octect_length
+syn keyword sqlxSqlFunction parse_date parse_time parse_timestamp percentile_count percentile_disc percent_rank pow power
+syn keyword sqlxSqlFunction rand range_bucket rank rollup round row_number regexp_contains regexp_extract regexp_extract_all regexp_instr regexp_replace regexp_substr
+syn keyword sqlxSqlFunction replace repeat reverse right rpad rtrim
+syn keyword sqlxSqlFunction safe_cast safe_divide safe_multiply safe_negat safe_add safe_substract sha1 sha256 sha512 sign sqrt sin sinh session_user
+syn keyword sqlxSqlFunction st_geogpoint st_makeline st_makepolygon st_makepolygonoriented st_geogfromgeojson st_geogfromtext st_geogfromwkb st_geogpointfromgeohash
+syn keyword sqlxSqlFunction st_asbinary st_asgeojson st_astext st_geohash st_bounday st_centroid st_centroid_agg st_closestpoint st_convexhull st_difference st_dump
+syn keyword sqlxSqlFunction st_intersection st_simplify st_snaptogrid st_union st_union_agg st_dimension st_endpoint st_iscollection is_isempty st_npoint st_numpoints
+syn keyword sqlxSqlFunction st_pointn st_startpoint st_x st_y st_contains st_coverdby st_disjoint st_dwithin st_equals st_intersects st_intersectsbox st_touches
+syn keyword sqlxSqlFunction st_within st_area st_distance st_length st_maxdistance st_perimeter st_clusterdbscan
+syn keyword sqlxSqlFunction safe_convert_bytes_to_string safe_offset safe_ordinal soundex split start_with stddev stddev_pop stddev_samp strpos string string_agg substr sum
+syn keyword sqlxSqlFunction tan tanh time time_add time_sub time_diff time_trunc timestamp timestamp_add timestamp_sub timestamp_diff timestamp_trunc timestamp_seconds
+syn keyword sqlxSqlFunction timestamp_millis timestamp_micros to_json_string to_base32 to_base64 to_code_points to_hex translate trim trunc
+syn keyword sqlxSqlFunction unicode unix_date unix_seconds unix_millis unix_micros upper 
+syn keyword sqlxSqlFunction variance var_pop var_samp
+
+
+" Statements
+" ---------------------
+syn keyword sqlxSqlStatement case create
+syn keyword sqlxSqlStatement declare default delete drop
+syn keyword sqlxSqlStatement except
+syn keyword sqlxSqlStatement from
+syn keyword sqlxSqlStatement group
+syn keyword sqlxSqlStatement having
+syn keyword sqlxSqlStatement insert
+syn keyword sqlxSqlStatement replace
+syn keyword sqlxSqlStatement select set
+syn keyword sqlxSqlStatement qualify
+syn keyword sqlxSqlStatement truncate
+syn keyword sqlxSqlStatement update
+syn keyword sqlxSqlStatement window
+syn keyword sqlxSqlStatement limit
+
+
+" Operators
+" ---------------------
+syn keyword sqlxSqlOperator all and any
+syn keyword sqlxSqlOperator between
+syn keyword sqlxSqlOperator distinct
+syn keyword sqlxSqlOperator exists
+syn keyword sqlxSqlOperator in intersect is isnull
+syn keyword sqlxSqlOperator not
+syn keyword sqlxSqlOperator pivot
+syn keyword sqlxSqlOperator tamblesample
+syn keyword sqlxSqlOperator union unnest unpivot

--- a/syntax/sql/sqlx_bigquery.vim
+++ b/syntax/sql/sqlx_bigquery.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: SQLX
 " Maintainer: Andres Lowrie
-" Repository: https://github.com/andres-lowrie/vim-sqlx
+" Repository: https://github.com/magal1337/dataform.nvim
 " License: MIT
 
 " BigQuery Syntax

--- a/syntax/sqlx.vim
+++ b/syntax/sqlx.vim
@@ -1,0 +1,121 @@
+" Vim syntax file
+" Language: SQLX
+" Maintainer: Andres Lowrie
+" Repository: https://github.com/andres-lowrie/vim-sqlx
+" License: VIM
+" Credits: https://github.com/vim/vim/blob/master/runtime/syntax/sqloracle.vim
+
+
+" Need a way to know when we're in the process of setting up the syntax as
+" well as a way to exit if we've already setup the syntax
+if !exists("setting_up_sqlx")
+  if exists("b:current_syntax")
+    finish
+  endif
+  let setting_up_sqlx = 1
+endif
+
+
+syn case ignore
+
+
+" todo
+syn keyword sqlxTodo TODO FIXME XXX DEBUG NOTE contained
+
+
+" Strings
+syn match  sqlxSqlSpecial contained "\v\\%(x\x\x|u%(\x{4}|\{\x{4,5}})|c\u|.)"
+syn region sqlxSqlString  start=+\z(["'`]\)+  skip=+\\\%(\z1\|$\)+  end=+\z1+ end=+$+ contains=sqlxSqlSpecial extend
+
+
+" Comments
+syn region sqlxSqlComment start="/\*" end="\*/"  contains=sqlxTodo,@Spell fold
+syn match  sqlxSqlComment "--.*$"                contains=sqlxTodo,@Spell
+syn match  sqlxSqlComment "#.*$"                 contains=sqlxTodo,@Spell
+syn sync   ccomment sqlxSqlComment
+
+
+" SQL Dialects
+" ---------------------
+"  
+" These should be keywords, statements, operators, and those types of thing.
+" Note that "group-name" should follow the following pattern in order to not
+" collide with the javascript "group-name"s:
+"
+" {prefix}Sql{group-name} eg:
+"
+" sqlxSqlKeyword or
+" sqlxSqlType
+"
+" Basically with "Sql" following the prefix "sqlx"
+"
+"
+" Picking a dialect happens using the following precedence:
+"   - Reads the first line for a dialect
+"
+"         sqlx_dialect = 'some_supported_dialect'
+"
+"   - User sets the dialect via the variable 'g:sqlx_dialect' @TODO 
+let filename = 'base'
+
+if !exists("g:sqlx_dialect")
+  let firstline = getline(1)
+
+  if firstline =~ "sqlx_dialect"
+    let [_, dialect] = split(firstline, '=')
+    let g:sqlx_dialect = trim(dialect)
+  else
+    let g:sqlx_dialect = 'base'
+  endif
+
+endif
+
+if globpath(&runtimepath, 'syntax/sql/sqlx_'.g:sqlx_dialect.'.vim') != ''
+  let filename = g:sqlx_dialect
+else
+  " Setting the variable back to what it's defaulted to so that checks against
+  " the variable yield the expected result
+  echom "'".g:sqlx_dialect."' is not a supported dialect. Defaulting to 'base'"
+  let g:sqlx_dialect = 'base'
+endif
+
+exec 'runtime syntax/sql/sqlx_'.filename.'.vim'
+
+
+
+" Associate all SQL dialect syntax to highlight
+hi def link Quote            Special
+hi def link sqlxSqlSpecial   Special
+hi def link sqlxSqlFunction  Function
+hi def link sqlxSqlKeyword   Keyword
+hi def link sqlxSqlOperator  Operator
+hi def link sqlxSqlStatement Statement
+hi def link sqlxSqlType      Type
+hi def link sqlxSqlString    String
+hi def link sqlxSqlComment   Comment
+hi def link sqlxTodo         Todo
+
+
+
+
+" Javascript Syntax
+" ---------------------
+" 
+" SQLX allows for full on javascript code blocks:
+" - js {...}      = All JavaScript except module related stuff (...I think)
+" - config {...}  = Anything that can be defined within an 'Object'
+" - ${...}        = Any 'In-Line' JavaScript...which probably means all JS
+"                   since whitespace is insignificant in js
+syn include @Js syntax/sqlx_javascript.vim
+
+syn region sqlxSqlJsBlock matchgroup=sqlxSqlJsBlockId start="config {" end="}" contains=@Js keepend fold extend
+syn region sqlxSqlJsBlock matchgroup=sqlxSqlJsBlockId start="js {"     end="}" contains=@Js keepend fold extend
+syn region sqlxSqlJsBlock matchgroup=sqlxSqlJsBlockId start="${"       end="}" contains=@Js keepend fold extend
+
+hi def link sqlxSqlJsBlockId  Special
+
+
+let b:current_syntax = "sqlx"
+if setting_up_sqlx == 1
+  unlet setting_up_sqlx
+endif

--- a/syntax/sqlx.vim
+++ b/syntax/sqlx.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: SQLX
 " Maintainer: Andres Lowrie
-" Repository: https://github.com/andres-lowrie/vim-sqlx
+" Repository: https://github.com/magal1337/dataform.nvim
 " License: VIM
 " Credits: https://github.com/vim/vim/blob/master/runtime/syntax/sqloracle.vim
 

--- a/syntax/sqlx_javascript.vim
+++ b/syntax/sqlx_javascript.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: SQLX
 " Maintainer: Andres Lowrie
-" Repository: https://github.com/andres-lowrie/vim-sqlx
+" Repository: https://github.com/magal1337/dataform.nvim
 " License: VIM
 " Credits: https://github.com/pangloss/vim-javascript
 "

--- a/syntax/sqlx_javascript.vim
+++ b/syntax/sqlx_javascript.vim
@@ -1,0 +1,316 @@
+" Vim syntax file
+" Language: SQLX
+" Maintainer: Andres Lowrie
+" Repository: https://github.com/andres-lowrie/vim-sqlx
+" License: VIM
+" Credits: https://github.com/pangloss/vim-javascript
+"
+
+
+" Allow $ in identifiers
+if (v:version > 704 || v:version == 704 && has('patch1142')) && setting_up_sqlx
+  syntax iskeyword @,48-57,_,192-255,$
+else
+  syntax iskeyword+=$
+endif
+
+
+" Grammar Constructs
+" ---------------------
+syn match sqlxJsNoise       /[:,;]/
+syn match sqlxJsDot         /\./ skipwhite skipempty nextgroup=sqlxJsObjectProp,sqlxJsFuncCall,sqlxJsTaggedTemplate
+syn match sqlxJsFuncCall    /\<\K\k*\ze\s*(/
+syn match sqlxJsParensError /[(}\]]/
+
+
+" Types and Builtin
+" ---------------------
+syn keyword sqlxJsGlobalObjects ArrayBuffer Array BigInt BigInt64Array BigUint64Array Float32Array Float64Array Int16Array Int32Array Int8Array Uint16Array Uint32Array Uint8Array Uint8ClampedArray Boolean Buffer Collator DataView Date DateTimeFormat Function Intl Iterator JSON Map Set WeakMap WeakRef WeakSet Math Number NumberFormat Object ParallelArray Promise Proxy Reflect RegExp String Symbol Uint8ClampedArray WebAssembly console document fetch window
+syn keyword sqlxJsExceptions    Error EvalError InternalError RangeError ReferenceError StopIteration SyntaxError TypeError URIError
+syn keyword sqlxJsBuiltins      decodeURI decodeURIComponent encodeURI encodeURIComponent eval isFinite isNaN parseFloat parseInt uneval
+
+
+" Operators
+" ---------------------
+syn match sqlxJsOperator "[-!|&+<>=%/*~^]" skipwhite skipempty nextgroup=@sqlxJsExpression
+
+
+" Strings and Templates
+" ---------------------
+syn region sqlxJsString         start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1+ end=+$+  contains=sqlxJsSpecial extend
+syn region sqlxJsTemplateString start=+`+  skip=+\\`+  end=+`+ contains=sqlxJsTemplateExpression,sqlxJsSpecial extend
+syn match  sqlxJsTaggedTemplate /\<\K\k*\ze`/ nextgroup=sqlxJsTemplateString
+
+
+" Numbers
+" ---------------------
+syn match   sqlxJsNumber /\c\<\%(\d\+\%(e[+-]\=\d\+\)\=\|0b[01]\+\|0o\o\+\|0x\%(\x\|_\)\+\)n\=\>/
+syn keyword sqlxJsNumber Infinity
+syn match   sqlxJsFloat  /\c\<\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%(e[+-]\=\d\+\)\=\>/
+
+
+" Regex
+" ---------------------
+syn match   sqlxJsSpecial            contained "\v\\%(x\x\x|u%(\x{4}|\{\x{4,5}})|c\u|.)"
+syn region  sqlxJsTemplateExpression contained matchgroup=sqlxJsTemplateBraces start=+${+ end=+}+ contains=@sqlxJsExpression keepend
+syn region  sqlxJsRegexpCharClass    contained start=+\[+ skip=+\\.+ end=+\]+ contains=sqlxJsSpecial extend
+syn match   sqlxJsRegexpBoundary     contained "\v\c[$^]|\\b"
+syn match   sqlxJsRegexpBackRef      contained "\v\\[1-9]\d*"
+syn match   sqlxJsRegexpQuantifier   contained "\v[^\\]%([?*+]|\{\d+%(,\d*)?})\??"lc=1
+syn match   sqlxJsRegexpOr           contained "|"
+syn match   sqlxJsRegexpMod          contained "\v\(\?[:=!>]"lc=1
+syn region  sqlxJsRegexpGroup        contained start="[^\\]("lc=1 skip="\\.\|\[\(\\.\|[^]]\+\)\]" end=")" contains=sqlxJsRegexpCharClass,@sqlxJsRegexpSpecial keepend
+syn region  sqlxJsRegexpString                 start=+\%(\%(\<return\|\<typeof\|\_[^)\]'"[:blank:][:alnum:]_$]\)\s*\)\@<=/\ze[^*/]+ skip=+\\.\|\[[^]]\{1,}\]+ end=+/[gimyus]\{,6}+ contains=sqlxJsRegexpCharClass,sqlxJsRegexpGroup,@sqlxJsRegexpSpecial oneline keepend extend
+syn cluster sqlxJsRegexpSpecial      contains=sqlxJsSpecial,sqlxJsRegexpBoundary,sqlxJsRegexpBackRef,sqlxJsRegexpQuantifier,sqlxJsRegexpOr,sqlxJsRegexpMod
+
+
+" Objects
+" ---------------------
+syn match  sqlxJsObjectProp          contained /\<\K\k*/
+syn match  sqlxJsObjectShorthandProp contained /\<\k*\ze\s*/ skipwhite skipempty nextgroup=sqlxJsObjectSeparator
+syn match  sqlxJsObjectKey           contained /\<\k*\ze\s*:/ contains=sqlxJsFunctionKey skipwhite skipempty nextgroup=sqlxJsObjectValue
+syn region sqlxJsObjectKeyString     contained start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1\|$+  contains=sqlxJsSpecial skipwhite skipempty nextgroup=sqlxJsObjectValue
+syn region sqlxJsObjectKeyComputed   contained matchgroup=sqlxJsBrackets start=/\[/ end=/]/ contains=@sqlxJsExpression skipwhite skipempty nextgroup=sqlxJsObjectValue,sqlxJsFuncArgs extend
+syn match  sqlxJsObjectSeparator     contained /,/
+syn region sqlxJsObjectValue         contained matchgroup=sqlxJsObjectColon start=/:/ end=/[,}]\@=/ contains=@sqlxJsExpression extend
+syn match  sqlxJsObjectFuncName      contained /\<\K\k*\ze\_s*(/ skipwhite skipempty nextgroup=sqlxJsFuncArgs
+syn match  sqlxJsFunctionKey         contained /\<\K\k*\ze\s*:\s*function\>/
+syn match  sqlxJsObjectMethodType    contained /\<[gs]et\ze\s\+\K\k*/ skipwhite skipempty nextgroup=sqlxJsObjectFuncName
+syn region sqlxJsObjectStringKey     contained start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1\|$+  contains=sqlxJsSpecial extend skipwhite skipempty nextgroup=sqlxJsFuncArgs,sqlxJsObjectValue
+
+
+" Classes
+" ---------------------
+syn keyword sqlxJsClassKeyword           contained class
+syn keyword sqlxJsExtendsKeyword         contained extends skipwhite skipempty nextgroup=@sqlxJsExpression
+syn match   sqlxJsClassNoise             contained /\./
+syn match   sqlxJsClassFuncName          contained /\<\K\k*\ze\s*[(<]/ skipwhite skipempty nextgroup=sqlxJsFuncArgs
+syn match   sqlxJsClassMethodType        contained /\<\%([gs]et\|static\)\ze\s\+\K\k*/ skipwhite skipempty nextgroup=sqlxJsAsyncKeyword,sqlxJsClassFuncName,sqlxJsClassProperty
+syn region  sqlxJsClassDefinition                  start=/\<class\>/ end=/\(\<extends\>\s\+\)\@<!{\@=/ contains=sqlxJsClassKeyword,sqlxJsExtendsKeyword,sqlxJsClassNoise,@sqlxJsExpression skipwhite skipempty nextgroup=sqlxJsCommentClass,sqlxJsClassBlock
+syn match   sqlxJsClassProperty          contained /\<\K\k*\ze\s*[=;]/ skipwhite skipempty nextgroup=sqlxJsClassValue
+syn region  sqlxJsClassValue             contained start=/=/ end=/\_[;}]\@=/ contains=@sqlxJsExpression
+syn region  sqlxJsClassPropertyComputed  contained matchgroup=sqlxJsBrackets start=/\[/ end=/]/ contains=@sqlxJsExpression skipwhite skipempty nextgroup=sqlxJsFuncArgs,sqlxJsClassValue extend
+syn region  sqlxJsClassStringKey         contained start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1\|$+  contains=sqlxJsSpecial extend skipwhite skipempty nextgroup=sqlxJsFuncArgs
+
+
+" Destructuring
+" ---------------------
+syn match  sqlxJsDestructuringPropertyValue     contained /\k\+/
+syn match  sqlxJsDestructuringProperty          contained /\k\+\ze\s*=/ skipwhite skipempty nextgroup=sqlxJsDestructuringValue
+syn match  sqlxJsDestructuringAssignment        contained /\k\+\ze\s*:/ skipwhite skipempty nextgroup=sqlxJsDestructuringValueAssignment
+syn region sqlxJsDestructuringValue             contained start=/=/ end=/[,}\]]\@=/ contains=@sqlxJsExpression extend
+syn region sqlxJsDestructuringValueAssignment   contained start=/:/ end=/[,}=]\@=/ contains=sqlxJsDestructuringPropertyValue,sqlxJsDestructuringBlock,sqlxJsNoise,sqlxJsDestructuringNoise skipwhite skipempty nextgroup=sqlxJsDestructuringValue extend
+syn match  sqlxJsDestructuringNoise             contained /[,[\]]/
+syn region sqlxJsDestructuringPropertyComputed  contained matchgroup=sqlxJsDestructuringBraces start=/\[/ end=/]/ contains=@sqlxJsExpression skipwhite skipempty nextgroup=sqlxJsDestructuringValue,sqlxJsDestructuringValueAssignment,sqlxJsDestructuringNoise extend fold
+
+
+" Comments
+" ---------------------
+syn region  sqlxJsComment        start=+//+ end=/$/ contains=sqlxTodo,@Spell extend keepend
+syn region  sqlxJsComment        start=+/\*+  end=+\*/+ contains=sqlxTodo,@Spell fold extend keepend
+syn region  sqlxJsEnvComment     start=/\%^#!/ end=/$/ display
+
+
+" Specialized Comments - These are special comment regexes that are used in
+" odd places that maintain the proper nextgroup functionality. It sucks we
+" can't make jsComment a skippable type of group for nextgroup
+syn region sqlxJsCommentFunction contained start=+//+ end=/$/    contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsFuncBlock extend keepend
+syn region sqlxJsCommentFunction contained start=+/\*+ end=+\*/+ contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsFuncBlock fold extend keepend
+syn region sqlxJsCommentClass    contained start=+//+ end=/$/    contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsClassBlock extend keepend
+syn region sqlxJsCommentClass    contained start=+/\*+ end=+\*/+ contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsClassBlock fold extend keepend
+syn region sqlxJsCommentIfElse   contained start=+//+ end=/$/    contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsIfElseBlock extend keepend
+syn region sqlxJsCommentIfElse   contained start=+/\*+ end=+\*/+ contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsIfElseBlock fold extend keepend
+syn region sqlxJsCommentRepeat   contained start=+//+ end=/$/    contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsRepeatBlock extend keepend
+syn region sqlxJsCommentRepeat   contained start=+/\*+ end=+\*/+ contains=sqlxTodo,@Spell skipwhite skipempty nextgroup=sqlxJsRepeatBlock fold extend keepend
+
+
+" Decorators
+" ---------------------
+syn match sqlxJsDecorator                    /^\s*@/ nextgroup=sqlxJsDecoratorFunction
+syn match sqlxJsDecoratorFunction  contained /\h[a-zA-Z0-9_.]*/ nextgroup=sqlxJsParenDecorator
+
+
+
+" Keywords
+" ---------------------
+syn keyword sqlxJsStorageClass              const let skipwhite skipempty nextgroup=sqlxJsDestructuringBlock,sqlxJsDestructuringArray,sqlxJsVariableDef
+syn keyword sqlxJsStorageClass              const let skipwhite skipempty
+syn keyword sqlxJsOperatorKeyword           delete instanceof typeof void new in of skipwhite skipempty nextgroup=@sqlxJsExpression
+syn keyword sqlxJsBoolean                   true false
+syn keyword sqlxJsNull                      null
+syn keyword sqlxJsReturn                    return contained skipwhite nexgroup@sqlxJsExpression
+syn keyword sqlxJsUndefined                 undefined
+syn keyword sqlxJsNan                       NaN
+syn keyword sqlxJsPrototype                 prototype
+syn keyword sqlxJsThis                      this
+syn keyword sqlxJsSuper                     super
+syn keyword sqlxJsException                 throw
+syn keyword sqlxJsAsyncKeyword              async await
+syn keyword sqlxJsConditional               if skipwhite skipempty nextgroup=sqlxJsParenIfElse
+syn keyword sqlxJsConditional               else skipwhite skipempty nextgroup=sqlxJsCommentIfElse,sqlxJsIfElseBlock
+syn keyword sqlxJsConditional               switch skipwhite skipempty nextgroup=sqlxJsParenSwitch
+syn keyword sqlxJsRepeat                    while for skipwhite skipempty nextgroup=sqlxJsParenRepeat,sqlxJsForAwait
+syn region  sqlxJsSwitchCase      contained start=/\<\%(case\|default\)\>/ end=/:\@=/ contains=@sqlxJsExpression skipwhite skipempty nextgroup=sqlxJsSwitchColon keepend
+syn keyword sqlxJsTry                       try skipwhite skipempty nextgroup=sqlxJsTryCatchBlock
+syn keyword sqlxJsFinally         contained finally skipwhite skipempty nextgroup=sqlxJsFinallyBlock
+syn keyword sqlxJsCatch           contained catch skipwhite skipempty nextgroup=sqlxJsParenCatch,sqlxJsTryCatchBlock
+syn match   sqlxJsSwitchColon     contained /::\@!/ skipwhite skipempty nextgroup=sqlxJsSwitchBlock
+
+
+" Code blocks
+" ---------------------
+syn region sqlxJsBracket                      matchgroup=sqlxJsBrackets            start=/\[/ end=/\]/ contains=@sqlxJsExpression,sqlxJsSpreadExpression extend fold
+syn region sqlxJsParen                        matchgroup=sqlxJsParens              start=/(/  end=/)/  contains=@sqlxJsExpression extend fold
+syn region sqlxJsParenDecorator     contained matchgroup=sqlxJsParensDecorator     start=/(/  end=/)/  contains=@sqlxJsAll extend fold
+syn region sqlxJsParenIfElse        contained matchgroup=sqlxJsParensIfElse        start=/(/  end=/)/  contains=@sqlxJsAll skipwhite skipempty nextgroup=sqlxJsCommentIfElse,sqlxJsIfElseBlock,sqlxJsReturn extend fold
+syn region sqlxJsParenRepeat        contained matchgroup=sqlxJsParensRepeat        start=/(/  end=/)/  contains=@sqlxJsAll skipwhite skipempty nextgroup=sqlxJsCommentRepeat,sqlxJsRepeatBlock,sqlxJsReturn extend fold
+syn region sqlxJsParenSwitch        contained matchgroup=sqlxJsParensSwitch        start=/(/  end=/)/  contains=@sqlxJsAll skipwhite skipempty nextgroup=sqlxJsSwitchBlock extend fold
+syn region sqlxJsParenCatch         contained matchgroup=sqlxJsParensCatch         start=/(/  end=/)/  skipwhite skipempty nextgroup=sqlxJsTryCatchBlock extend fold
+syn region sqlxJsFuncArgs           contained matchgroup=sqlxJsFuncParens          start=/(/  end=/)/  contains=sqlxJsFuncArgCommas,sqlxJsComment,sqlxJsFuncArgExpression,sqlxJsDestructuringBlock,sqlxJsDestructuringArray,sqlxJsRestExpression skipwhite skipempty nextgroup=sqlxJsCommentFunction,sqlxJsFuncBlock extend fold
+syn region sqlxJsClassBlock         contained matchgroup=sqlxJsClassBraces         start=/{/  end=/}/  contains=sqlxJsClassFuncName,sqlxJsClassMethodType,sqlxJsArrowFunction,sqlxJsArrowFuncArgs,sqlxJsComment,sqlxJsGenerator,sqlxJsDecorator,sqlxJsClassProperty,sqlxJsClassPropertyComputed,sqlxJsClassStringKey,sqlxJsAsyncKeyword,sqlxJsNoise extend fold
+syn region sqlxJsFuncBlock          contained matchgroup=sqlxJsFuncBraces          start=/{/  end=/}/  contains=@sqlxJsAll,sqlxJsBlock extend fold
+syn region sqlxJsIfElseBlock        contained matchgroup=sqlxJsIfElseBraces        start=/{/  end=/}/  contains=@sqlxJsAll,sqlxJsBlock extend fold
+syn region sqlxJsTryCatchBlock      contained matchgroup=sqlxJsTryCatchBraces      start=/{/  end=/}/  contains=@sqlxJsAll,sqlxJsBlock skipwhite skipempty nextgroup=sqlxJsCatch,sqlxJsFinally extend fold
+syn region sqlxJsFinallyBlock       contained matchgroup=sqlxJsFinallyBraces       start=/{/  end=/}/  contains=@sqlxJsAll,sqlxJsBlock extend fold
+syn region sqlxJsSwitchBlock        contained matchgroup=sqlxJsSwitchBraces        start=/{/  end=/}/  contains=@sqlxJsAll,sqlxJsBlock,sqlxJsSwitchCase extend fold
+syn region sqlxJsRepeatBlock        contained matchgroup=sqlxJsRepeatBraces        start=/{/  end=/}/  contains=@sqlxJsAll,sqlxJsBlock extend fold
+syn region sqlxJsDestructuringBlock contained matchgroup=sqlxJsDestructuringBraces start=/{/  end=/}/  contains=sqlxJsDestructuringProperty,sqlxJsDestructuringAssignment,sqlxJsDestructuringNoise,sqlxJsDestructuringPropertyComputed,sqlxJsSpreadExpression,sqlxJsComment extend fold
+syn region sqlxJsDestructuringArray contained matchgroup=sqlxJsDestructuringBraces start=/\[/ end=/\]/ contains=sqlxJsDestructuringPropertyValue,sqlxJsDestructuringNoise,sqlxJsDestructuringProperty,sqlxJsSpreadExpression,sqlxJsDestructuringBlock,sqlxJsDestructuringArray,sqlxJsComment extend fold
+syn region sqlxJsObject             contained matchgroup=sqlxJsObjectBraces        start=/{/  end=/}/  contains=sqlxJsObjectKey,sqlxJsObjectKeyString,sqlxJsObjectKeyComputed,sqlxJsObjectShorthandProp,sqlxJsObjectSeparator,sqlxJsObjectFuncName,sqlxJsObjectMethodType,sqlxJsGenerator,sqlxJsComment,sqlxJsObjectStringKey,sqlxJsSpreadExpression,sqlxJsDecorator,sqlxJsAsyncKeyword,sqlxJsTemplateString extend fold
+syn region sqlxJsBlock                        matchgroup=sqlxJsBraces              start=/{/  end=/}/  contains=@sqlxJsAll,sqlxJsSpreadExpression,sqlxJsTemplateString extend fold
+syn region sqlxJsSpreadExpression   contained matchgroup=sqlxJsSpreadOperator      start=/\.\.\./ end=/[,}\]]\@=/ contains=@sqlxJsExpression
+syn region sqlxJsRestExpression     contained matchgroup=sqlxJsRestOperator        start=/\.\.\./ end=/[,)]\@=/
+syn region sqlxJsTernaryIf                    matchgroup=sqlxJsTernaryIfOperator   start=/?:\@!/  end=/\%(:\|}\@=\)/  contains=@sqlxJsExpression extend skipwhite skipempty nextgroup=@sqlxJsExpression
+
+
+" These must occur here or they will be over written by jsTernaryIf
+syn match sqlxJsOperator /?\.\ze\_D/
+syn match sqlxJsOperator /??/ skipwhite skipempty nextgroup=@sqlxJsExpression
+
+syn match   sqlxJsGenerator         contained /\*/ skipwhite skipempty nextgroup=sqlxJsFuncName,sqlxJsFuncArgs
+syn match   sqlxJsFuncName          contained /\<\K\k*/ skipwhite skipempty nextgroup=sqlxJsFuncArgs
+syn region  sqlxJsFuncArgExpression contained matchgroup=sqlxJsFuncArgOperator start=/=/ end=/[,)]\@=/ contains=@sqlxJsExpression extend
+syn match   sqlxJsFuncArgCommas     contained ','
+syn keyword sqlxJsArguments         contained arguments
+syn keyword sqlxJsForAwait          contained await skipwhite skipempty nextgroup=sqlxJsParenRepeat
+
+" Matches a single keyword argument with no parens and the (iffe) arrow
+syn match sqlxJsArrowFuncArgs /\<\K\k*\ze\s*=>/ skipwhite contains=sqlxJsFuncArgs skipwhite skipempty nextgroup=sqlxJsArrowFunction extend
+syn match sqlxJsArrowFuncArgs /([^()]*)\ze\s*=>/ contains=sqlxJsFuncArgs skipempty skipwhite nextgroup=sqlxJsArrowFunction extend
+
+syn match sqlxJsFunction      /\<function\>/ skipwhite skipempty nextgroup=sqlxJsGenerator,sqlxJsFuncName,sqlxJsFuncArgs skipwhite
+syn match sqlxJsArrowFunction /=>/           skipwhite skipempty nextgroup=sqlxJsFuncBlock,sqlxJsCommentFunction
+syn match sqlxJsArrowFunction /()\ze\s*=>/   skipwhite skipempty nextgroup=sqlxJsArrowFunction
+syn match sqlxJsArrowFunction /_\ze\s*=>/    skipwhite skipempty nextgroup=sqlxJsArrowFunction
+  
+syn cluster sqlxJsExpression  contains=sqlxJsBracket,sqlxJsParen,sqlxJsObject,sqlxJsTernaryIf,sqlxJsTaggedTemplate,sqlxJsTemplateString,sqlxJsString,sqlxJsRegexpString,sqlxJsNumber,sqlxJsFloat,sqlxJsOperator,sqlxJsOperatorKeyword,sqlxJsBooleanTrue,sqlxJsBooleanFalse,sqlxJsNull,sqlxJsFunction,sqlxJsArrowFunction,sqlxJsGlobalObjects,sqlxJsExceptions,sqlxJsFuncCall,sqlxJsUndefined,sqlxJsNan,sqlxJsPrototype,sqlxJsBuiltins,sqlxJsNoise,sqlxJsClassDefinition,sqlxJsArrowFunction,sqlxJsArrowFuncArgs,sqlxJsParensError,sqlxJsComment,sqlxJsArguments,sqlxJsThis,sqlxJsSuper,sqlxJsForAwait,sqlxJsAsyncKeyword,sqlxJsStatement,sqlxJsDot
+syn cluster sqlxJsAll         contains=@sqlxJsExpression,sqlxJsStorageClass,sqlxJsConditional,sqlxJsRepeat,sqlxJsReturn,sqlxJsException,sqlxJsTry,sqlxJsNoise
+
+
+" Link
+" ---------------------
+hi def link sqlxJsArguments               Special
+hi def link sqlxJsArrowFuncArgs           sqlxJsFuncArgs
+hi def link sqlxJsArrowFunction           Type
+hi def link sqlxJsAsyncKeyword            Keyword
+hi def link sqlxJsBooleanFalse            Boolean
+hi def link sqlxJsBooleanTrue             Boolean
+hi def link sqlxJsBraces                  Noise
+hi def link sqlxJsBrackets                Noise
+hi def link sqlxJsBranch                  Conditional
+hi def link sqlxJsBuiltins                Constant
+hi def link sqlxJsCatch                   Exception
+hi def link sqlxJsCharacter               Character
+hi def link sqlxJsClassBraces             Noise
+hi def link sqlxJsClassDefinition         sqlxJsFuncName
+hi def link sqlxJsClassFuncName           sqlxJsFuncName
+hi def link sqlxJsClassKeyword            Keyword
+hi def link sqlxJsClassMethodType         Type
+hi def link sqlxJsClassNoise              Noise
+hi def link sqlxJsClassProperty           sqlxJsObjectKey
+hi def link sqlxJsClassStringKey          String
+hi def link sqlxJsComment                 Comment
+hi def link sqlxJsCommentClass            sqlxJsComment
+hi def link sqlxJsCommentFunction         sqlxJsComment
+hi def link sqlxJsCommentIfElse           sqlxJsComment
+hi def link sqlxJsCommentRepeat           sqlxJsComment
+hi def link sqlxJsConditional             Conditional
+hi def link sqlxJsDecorator               Special
+hi def link sqlxJsDecoratorFunction       Function
+hi def link sqlxJsDestructuringAssignment sqlxJsObjectKey
+hi def link sqlxJsDestructuringBraces     Noise
+hi def link sqlxJsDestructuringNoise      Noise
+hi def link sqlxJsDestructuringProperty   sqlxJsFuncArgs
+hi def link sqlxJsDo                      Repeat
+hi def link sqlxJsDot                     Noise
+hi def link sqlxJsEnvComment              PreProc
+hi def link sqlxJsError                   Error
+hi def link sqlxJsException               Exception
+hi def link sqlxJsExceptions              Constant
+hi def link sqlxJsExportDefault           StorageClass
+hi def link sqlxJsExportDefaultGroup      jsExportDefault
+hi def link sqlxJsExtendsKeyword          Keyword
+hi def link sqlxJsFinally                 Exception
+hi def link sqlxJsFinallyBraces           Noise
+hi def link sqlxJsFloat                   Float
+hi def link sqlxJsForAwait                Keyword
+hi def link sqlxJsFuncArgOperator         sqlxJsFuncArgs
+hi def link sqlxJsFuncBraces              Noise
+hi def link sqlxJsFuncCall                Function
+hi def link sqlxJsFuncName                Function
+hi def link sqlxJsFuncParens              Noise
+hi def link sqlxJsFunction                Type
+hi def link sqlxJsGenerator               sqlxJsFunction
+hi def link sqlxJsGlobalObjects           Constant
+hi def link sqlxJsIfElseBraces            Noise
+hi def link sqlxJsNan                     Number
+hi def link sqlxJsNoise                   Noise
+hi def link sqlxJsNull                    Type
+hi def link sqlxJsNumber                  Number
+hi def link sqlxJsObjectBraces            Noise
+hi def link sqlxJsObjectColon             jsNoise
+hi def link sqlxJsObjectFuncName          Function
+hi def link sqlxJsObjectKeyString         String
+hi def link sqlxJsObjectMethodType        Type
+hi def link sqlxJsObjectSeparator         Noise
+hi def link sqlxJsObjectShorthandProp     sqlxJsObjectKey
+hi def link sqlxJsObjectStringKey         String
+hi def link sqlxJsOperator                Operator
+hi def link sqlxJsOperatorKeyword         sqlxJsOperator
+hi def link sqlxJsParens                  Noise
+hi def link sqlxJsParensCatch             sqlxJsParens
+hi def link sqlxJsParensDecorator         sqlxJsParens
+hi def link sqlxJsParensError             Error
+hi def link sqlxJsParensIfElse            sqlxJsParens
+hi def link sqlxJsParensRepeat            sqlxJsParens
+hi def link sqlxJsParensSwitch            sqlxJsParens
+hi def link sqlxJsPrototype               Special
+hi def link sqlxJsRegexpBackRef           SpecialChar
+hi def link sqlxJsRegexpBoundary          SpecialChar
+hi def link sqlxJsRegexpCharClass         Character
+hi def link sqlxJsRegexpGroup             sqlxJsRegexpString
+hi def link sqlxJsRegexpMod               SpecialChar
+hi def link sqlxJsRegexpOr                Conditional
+hi def link sqlxJsRegexpQuantifier        SpecialChar
+hi def link sqlxJsRegexpString            String
+hi def link sqlxJsRepeat                  Repeat
+hi def link sqlxJsRepeatBraces            Noise
+hi def link sqlxJsRestExpression          sqlxJsFuncArgs
+hi def link sqlxJsRestOperator            Operator
+hi def link sqlxJsReturn                  Statement
+hi def link sqlxJsSpecial                 Special
+hi def link sqlxJsSpreadOperator          Operator
+hi def link sqlxJsStatement               Statement
+hi def link sqlxJsStorageClass            StorageClass
+hi def link sqlxJsString                  String
+hi def link sqlxJsSuper                   Constant
+hi def link sqlxJsSwitchBraces            Noise
+hi def link sqlxJsSwitchColon             Noise
+hi def link sqlxJsTaggedTemplate          StorageClass
+hi def link sqlxJsTemplateBraces          Noise
+hi def link sqlxJsTemplateString          String
+hi def link sqlxJsTernaryIfOperator       Operator
+hi def link sqlxJsThis                    Special
+hi def link sqlxJsTry                     Exception
+hi def link sqlxJsTryCatchBraces          Noise
+hi def link sqlxJsUndefined               Type


### PR DESCRIPTION
Hello 

Hey so I copied and pasted the syntax code and it seems to work with neovim (see picture below for lazy loading the plugin)

I saw that the current plugin already set's the filetype and all that so I figured those files are not needed here. 

I'm probably going to go do down the [treesitter](https://tree-sitter.github.io/tree-sitter/) rabbit hole and see if I can create a grammar for `.sqlx` using that since that appears to be the "preferred" method for neovim so I may send up a PR in the future if I get it to work; might be awhile since I only have a high level/abstract understanding of how the treesitter works, anyway just wanted to call that out 

----

Here's the screenshot of this loading up in my environment 

<img width="2055" alt="dataform-loading" src="https://github.com/magal1337/dataform.nvim/assets/6182700/da1a4f55-7221-463b-9aa6-19d64b38e610">


```lua
require('lazy').setup({
  'andres-lowrie/dataform.nvim',
...
```

you can see that Lazy has marked the old vim-sqlx as `Clean` and has `Loaded` this code so yay!!!