### PR TITLE
Add nvim-cmp and blink.cmp source for Dataform action completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - Run dataform specific tag
 - Syntax highlighting for both sql and javascript blocks
 - Search for dependencies and dependents for a specific model
-- Autocompletion for Dataform action names (e.g., within `ref("...")`, `resolve("...")`) in `.sqlx` files using `nvim-cmp`.
+- Autocompletion for Dataform action names (e.g., within `ref("...")`, `resolve("...")`) in `.sqlx` files using `nvim-cmp` or `blink.cmp`.
 
 ## 📜 Requirements
 
@@ -49,10 +49,10 @@ use {
 
 ## 🚀 Completions
 
-This plugin provides an `nvim-cmp` source named `dataform_actions` for autocompleting Dataform action names.
+This plugin provides an `nvim-cmp` source named `dataform_actions` and `blink.cmp` source in module `dataform.completion.blink` for autocompleting Dataform action names.
 This is particularly useful when writing `ref("...")` or `resolve("...")` calls within the JavaScript blocks or string literals in your `.sqlx` files.
 
-#### Example Setup
+#### Example Setup for `nvim.cmp`
 To use the autocompletion, you need to add it to your `nvim-cmp` sources configuration, typically for the `sqlx` filetype.
 Here's how you can prepend the `dataform_actions` source to your existing global sources for `sqlx` files:
 
@@ -64,6 +64,27 @@ cmp.setup.filetype('sqlx', {
     { { name = 'dataform_actions' } },
     cmp.get_config().sources
   )
+})
+```
+
+#### Example Setup for `blink.cmp`
+To integrate the Dataform autocompletion with `blink.cmp`, you need to configure its sources to include the `dataform.completion.blink` module, either specifically for `sqlx` filetypes or add it to the list of `default` sources.
+
+Here's how you can set up `blink.cmp` to use the Dataform completion provider:
+```lua
+blink.setup({
+  sources = {
+    default = { 'lsp', 'path', 'snippets', 'buffer' },
+    providers = {
+      dataform = {
+        name = "Dataform",
+        module = "dataform.completion.blink",
+      },
+    },
+    per_filetype = {
+      sqlx = { 'dataform', 'lsp', 'path', 'snippets', 'buffer' }
+    },
+  },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - Run dataform specific tag
 - Syntax highlighting for both sql and javascript blocks
 - Search for dependencies and dependents for a specific model
+- Autocompletion for Dataform action names (e.g., within `ref("...")`, `resolve("...")`) in `.sqlx` files using `nvim-cmp`.
 
 ## 📜 Requirements
 
@@ -38,6 +39,26 @@ use {
     'nvim-telescope/telescope.nvim'
   },
 }
+```
+
+## 🚀 Completions
+
+This plugin provides an `nvim-cmp` source named `dataform_actions` for autocompleting Dataform action names.
+This is particularly useful when writing `ref("...")` or `resolve("...")` calls within the JavaScript blocks or string literals in your `.sqlx` files.
+
+#### Example Setup
+To use the autocompletion, you need to add it to your `nvim-cmp` sources configuration, typically for the `sqlx` filetype.
+Here's how you can prepend the `dataform_actions` source to your existing global sources for `sqlx` files:
+
+```lua
+local cmp = require('cmp')
+
+cmp.setup.filetype('sqlx', {
+  sources = vim.fn.extend(
+    { { name = 'dataform_actions' } },
+    cmp.get_config().sources
+  )
+})
 ```
 
 ## 🧙‍♂️ Usage

--- a/lua/dataform/completion/blink.lua
+++ b/lua/dataform/completion/blink.lua
@@ -4,7 +4,9 @@ local utils = require('dataform.completion.utils')
 --- @class blink.cmp.Source
 local source = {}
 
-function source:new()
+function source.new(opts)
+  local self = setmetatable({}, { __index = source })
+  self.opts = opts
   return self
 end
 

--- a/lua/dataform/completion/blink.lua
+++ b/lua/dataform/completion/blink.lua
@@ -1,0 +1,32 @@
+local utils = require('dataform.completion.utils')
+
+--- @module 'blink.cmp'
+--- @class blink.cmp.Source
+local source = {}
+
+function source:new()
+  return self
+end
+
+function source:enabled()
+  return vim.bo.filetype == 'sqlx' and utils.is_sqlx_js_string_syntax()
+end
+
+function source:get_trigger_characters()
+  return utils.trigger_characters()
+ end
+
+function source:get_completions(ctx, callback)
+  --- @type lsp.CompletionItem[]
+  local action_names = utils.action_names()
+
+  callback({
+    items = action_names,
+    is_incomplete_backward = false,
+    is_incomplete_forward = false,
+  })
+
+  return function() end
+end
+
+return source

--- a/lua/dataform/completion/cmp.lua
+++ b/lua/dataform/completion/cmp.lua
@@ -1,0 +1,19 @@
+local utils = require('dataform.completion.utils')
+
+local source = {}
+
+function source:is_available()
+  return utils.is_sqlx_js_string_syntax()
+end
+
+function source:complete(params, callback)
+  local action_names = utils.action_names()
+
+  callback(action_names)
+end
+
+function source:get_trigger_characters()
+  return utils.trigger_characters()
+end
+
+return source

--- a/lua/dataform/completion/cmp.lua
+++ b/lua/dataform/completion/cmp.lua
@@ -3,7 +3,7 @@ local utils = require('dataform.completion.utils')
 local source = {}
 
 function source:is_available()
-  return utils.is_sqlx_js_string_syntax()
+  return vim.bo.filetype == 'sqlx' and utils.is_sqlx_js_string_syntax()
 end
 
 function source:complete(params, callback)

--- a/lua/dataform/completion/utils.lua
+++ b/lua/dataform/completion/utils.lua
@@ -1,8 +1,7 @@
 local M = {}
 
-local dataform = require('dataform.project')
-
 function M.action_names()
+  local dataform = require('dataform.project')
   local compiled = dataform.compiled_project_table or {}
   local tables = compiled.tables or {}
 

--- a/lua/dataform/completion/utils.lua
+++ b/lua/dataform/completion/utils.lua
@@ -1,0 +1,36 @@
+local M = {}
+
+local dataform = require('dataform.project')
+
+function M.action_names()
+  local compiled = dataform.compiled_project_table or {}
+  local tables = compiled.tables or {}
+
+  local names = {}
+  for _, action in ipairs(tables) do
+    local target = action.target or {}
+    if target.name ~= nil then
+      table.insert(
+        names,
+        {
+          label = target.name,
+          kind = 9, -- Module
+          detail = action.fileName
+        }
+      )
+    end
+  end
+  return names
+end
+
+function M.is_sqlx_js_string_syntax()
+  local synID = vim.fn.synID(vim.fn.line("."), vim.fn.col("."), 1)
+  local synGroupName = vim.fn.synIDattr(synID, "name")
+  return synGroupName and synGroupName == "sqlxJsString"
+end
+
+function M.trigger_characters()
+  return { "'", '"' }
+end
+
+return M

--- a/lua/dataform/init.lua
+++ b/lua/dataform/init.lua
@@ -14,5 +14,6 @@ M.run_tag = dataform.run_tag
 M.run_assertions_job = dataform.run_assertions_job
 M.find_model_dependencies = dataform.find_model_dependencies
 M.find_model_dependents = dataform.find_model_dependents
+M.completion_cmp_source = require("dataform.completion.cmp")
 
 return M

--- a/plugin/dataform.vim
+++ b/plugin/dataform.vim
@@ -22,6 +22,13 @@ function! s:HandleSQLXEvent()
   endif
 endfunction
 
+lua << EOF
+  local has_cmp, cmp = pcall(require, 'cmp')
+  if has_cmp then
+    cmp.register_source('dataform_actions', require('dataform').completion_cmp_source)
+  end
+EOF
+
 autocmd BufWritePost *.sqlx execute "lua require('dataform').compile()"
 
 command! -nargs=0 DataformCompileFull lua require('dataform').get_compiled_sql_job()


### PR DESCRIPTION
Introduces `dataform_actions`, an `nvim-cmp` source for autocompleting Dataform action names (e.g., tables referenced in `ref("...")`).

- Completions trigger inside JavaScript string literals within `.sqlx` files.
- The source is automatically registered if `nvim-cmp` is detected.
- README updated with feature highlight and setup instructions.
