### PR TITLE
Add an option to disable compile on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ use {
     'rcarriga/nvim-notify',
     'nvim-telescope/telescope.nvim'
   },
+  config = function ()
+    require('dataform').setup({
+        -- refresh dataform metadata on each save
+        compile_on_save = true
+    })
+  end
 }
 ```
 
@@ -44,6 +50,16 @@ use {
 
 First time that you open a dataform project with a `.sqlx` file in neovim session, it will automatically compile the project.
 And also every time that you edit your `.sqlx` file, and hit `:w` it will recompile it again for you not worry to do it manually. 🔮
+
+
+This auto-compile on save behavior is controlled by the `compile_on_save` option in the plugin's `setup` function.
+
+
+If you set `compile_on_save = false` in the setup, the plugin will not automatically recompile on save.
+You can then trigger compilation manually at any time using the command:
+```vim
+lua require('dataform').compile()
+```
 
 ## 🌀 Commands
 | Command | Action | Arguments|

--- a/lua/dataform/init.lua
+++ b/lua/dataform/init.lua
@@ -4,8 +4,10 @@ local M = {}
 
 -- Routes calls made to this module to functions in the
 -- plugin's other modules.
+M.setup = dataform.setup
 M.set_dataform_workdir_project_path = dataform.set_dataform_workdir_project_path
 M.compile = dataform.compile
+M.compile_on_save = dataform.compile_on_save
 M.get_compiled_sql_job = dataform.get_compiled_sql_job
 M.go_to_ref = dataform.go_to_ref
 M.run_action_job = dataform.run_action_job

--- a/lua/dataform/project.lua
+++ b/lua/dataform/project.lua
@@ -4,6 +4,24 @@ local utils = require("dataform.utils")
 local dataform = {}
 dataform.compiled_project_table = {}
 
+---@alias DataformUserConfig table
+---@field compile_on_save boolean? (default: true) Automatically compile Dataform project on saving a .sqlx file.
+
+local default_config = {
+  compile_on_save = true,
+}
+dataform.config = vim.deepcopy(default_config)
+
+---@param user_config DataformUserConfig?
+function dataform.setup(user_config)
+  user_config = user_config or {}
+  for key, value in pairs(user_config) do
+    if default_config[key] ~= nil then
+      dataform.config[key] = value
+    end
+  end
+end
+
 function dataform.set_dataform_workdir_project_path()
   local current_path = utils.get_current_file_path()
   local is_match = string.match(current_path, "/definitions/.*")
@@ -220,6 +238,12 @@ function dataform.find_model_dependencies()
   end
 
   return utils.custom_picker("Model Dependencies", target_paths)
+end
+
+function dataform.compile_on_save()
+  if dataform.config.compile_on_save then
+    dataform.compile()
+  end
 end
 
 return dataform

--- a/plugin/dataform.vim
+++ b/plugin/dataform.vim
@@ -22,7 +22,7 @@ function! s:HandleSQLXEvent()
   endif
 endfunction
 
-autocmd BufWritePost *.sqlx execute "lua require('dataform').compile()"
+autocmd BufWritePost *.sqlx execute "lua require('dataform').compile_on_save()"
 
 command! -nargs=0 DataformCompileFull lua require('dataform').get_compiled_sql_job()
 command! -nargs=0 DataformCompileIncremental lua require('dataform').get_compiled_sql_job(true)


### PR DESCRIPTION
Add an option to disable compile on save via `setup()` and option called `compile_on_save`, which defaults to `true`.

Example of disabling `compile_on_save`
```
  {
    'https://github.com/magal1337/dataform.nvim',
    dependencies = {
      'rcarriga/nvim-notify',
      'nvim-telescope/telescope.nvim'
    },
    config = function ()
      require('dataform').setup({ compile_on_save = false })
    end
  }
```

Fixes #15 