### PR TITLE
Run `bq dry_run` asynchronously with configurable toggle

### DIFF
--- a/lua/dataform/project.lua
+++ b/lua/dataform/project.lua
@@ -5,9 +5,11 @@ dataform.compiled_project_table = {}
 
 ---@alias DataformUserConfig table
 ---@field compile_on_save boolean? (default: true) Automatically compile Dataform project on saving a .sqlx file.
+---@field bq_dry_run boolean? (default: true) Run `bq query --dry_run` after opening the SQL buffer and show the result as a notification.
 
 local default_config = {
   compile_on_save = true,
+  bq_dry_run = true,
 }
 dataform.config = vim.deepcopy(default_config)
 
@@ -60,11 +62,11 @@ function dataform.go_to_ref()
 
   local df_tables = dataform.compiled_project_table.tables or {}
   local df_declarations = dataform.compiled_project_table.declarations or {}
-  local tables = vim.fn.extend(df_tables, df_declarations)
+  local actions = vim.fn.extend(df_tables, df_declarations)
 
-  for _, table in pairs(tables) do
-    if table.target.name == table_name and (table.target.schema == schema or not schema)  then
-      return utils.open_file(table.fileName)
+  for _, action in pairs(actions) do
+    if action.target.name == table_name and (action.target.schema == schema or not schema)  then
+      return utils.open_file(action.fileName)
     end
   end
 end
@@ -85,27 +87,44 @@ function dataform.compile()
 end
 
 function dataform.get_compiled_sql_job(incremental)
-  local tables = dataform.compiled_project_table.tables
+  local actions = dataform.compiled_project_table.tables
 
-  for _, table in pairs(tables) do
-    if table.fileName == get_dataform_definitions_file_path() then
+  for _, action in pairs(actions) do
+    if action.fileName == get_dataform_definitions_file_path() then
       local preOpsKey = incremental and "incrementalPreOps" or "preOps"
       local postOpsKey = incremental and "incrementalPostOps" or "postOps"
       local queryKey = incremental and "incrementalQuery" or "query"
 
-      local preOps = type(table[preOpsKey]) == "table" and table[preOpsKey][1] or ""
-      local postOps = type(table[postOpsKey]) == "table" and table[postOpsKey][1] or ""
+      local preOps = type(action[preOpsKey]) == "table" and action[preOpsKey][1] or ""
+      local postOps = type(action[postOpsKey]) == "table" and action[postOpsKey][1] or ""
 
       local preOpsClean = preOps:gsub("%s+$", "")
       if preOpsClean:sub(-1) ~= ";" and preOps ~= "" then preOps = preOps .. ";" end
 
-      local composite_query = preOps .. table[queryKey] .. ";\n" .. postOps
-      local bq_command = "echo " .. vim.fn.shellescape(composite_query) .. " | bq query --dry_run"
+      local composite_query = preOps .. action[queryKey] .. ";\n" .. postOps
 
-      local _, result = utils.os_execute_with_status(bq_command)
+      utils.open_buffer_with_content(composite_query)
 
-      utils.notify(result, vim.log.levels.WARN)
-      return utils.open_buffer_with_content(composite_query)
+      if dataform.config.bq_dry_run then
+        local bq_command = "echo " .. vim.fn.shellescape(composite_query) .. " | bq query --dry_run"
+        local stdout_lines = {}
+        vim.fn.jobstart({ "sh", "-c", bq_command }, {
+          stdout_buffered = true,
+          on_stdout = function(_, data)
+            if data then vim.list_extend(stdout_lines, data) end
+          end,
+          on_exit = function(_, code)
+            local trimmed = table.concat(stdout_lines, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
+            if trimmed ~= "" then
+              vim.schedule(function()
+                utils.notify(trimmed, code == 0 and vim.log.levels.INFO or vim.log.levels.WARN)
+              end)
+            end
+          end,
+        })
+      end
+
+      return
     end
   end
 end
@@ -146,11 +165,11 @@ function dataform.run_action_job(full_refresh)
   local full_refresh = full_refresh or false
   local df_tables = dataform.compiled_project_table.tables or {}
   local df_operations = dataform.compiled_project_table.operations or {}
-  local tables = vim.fn.extend(df_tables, df_operations)
+  local actions = vim.fn.extend(df_tables, df_operations)
 
-  for _, table in pairs(tables) do
-    if table.fileName == get_dataform_definitions_file_path() then
-      local action = table.target.database .. "." .. table.target.schema .. "." .. table.target.name
+  for _, action in pairs(actions) do
+    if action.fileName == get_dataform_definitions_file_path() then
+      local action = action.target.database .. "." .. action.target.schema .. "." .. action.target.name
       local command = "dataform run --full-refresh=" .. tostring(full_refresh) .. " --actions=" .. action
 
       local status, content = utils.os_execute_with_status(command)


### PR DESCRIPTION
- Changes `bq query --dry_run` execution from synchronous (`os_execute_with_status`) to async (`vim.fn.jobstart`) so Neovim doesn't block while waiting for BigQuery validation
- Adds a `bq_dry_run` config option (default: `true`) to allow users to disable the dry run entirely
- Opens the compiled SQL buffer immediately without waiting for the dry run result
- Renames `table`/`tables` variables to `action`/`actions` to remove collision with lua builtin `table` across several functions