### PR TITLE
Add compilation result caching to skip recompiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ use {
   config = function ()
     require('dataform').setup({
         -- refresh dataform metadata on each save
-        compile_on_save = true
+        compile_on_save = true,
+        -- skip recompilation when project files are unchanged (in-memory)
+        cache = true,
+        -- persist cache to disk so it survives across Neovim sessions
+        cache_persist = false,
     })
   end
 }
@@ -111,6 +115,17 @@ You can then trigger compilation manually at any time using the command:
 lua require('dataform').compile()
 ```
 
+### Compilation Caching
+
+By default, the plugin skips recompilation when no project files have changed (based on file mtimes in `definitions/`, `includes/`, `package.json`, `dataform.json`, and `workflow_settings.yaml`). A `(cached)` notice will appear instead of running the CLI.
+
+Set `cache_persist = true` to persist the cache to disk so it survives Neovim restarts.
+
+To manually clear the cache:
+```vim
+:DataformClearCache
+```
+
 ## 🌀 Commands
 | Command | Action | Arguments|
 |---|---|---|
@@ -124,6 +139,7 @@ lua require('dataform').compile()
 |`:DataformRunAssertions`| Will run the current model assertions. ||
 |`:DataformFindDependencies`| Will return a Finder with all dependencies for current model ||
 |`:DataformFindDependents`| Will return a Finder with all dependents for current model ||
+|`:DataformClearCache`| Clears the in-memory and on-disk compilation cache, forcing a fresh compile on next trigger. ||
 
 🔮 It's recommended to use these commands encapsulated in some custom keymaps to make it more convenient. Choose what suits you best.
 ## 📖 Syntax Highlight

--- a/lua/dataform/init.lua
+++ b/lua/dataform/init.lua
@@ -16,6 +16,7 @@ M.run_tag = dataform.run_tag
 M.run_assertions_job = dataform.run_assertions_job
 M.find_model_dependencies = dataform.find_model_dependencies
 M.find_model_dependents = dataform.find_model_dependents
+M.clear_cache = dataform.clear_cache
 M.completion_cmp_source = require("dataform.completion.cmp")
 
 return M

--- a/lua/dataform/project.lua
+++ b/lua/dataform/project.lua
@@ -2,12 +2,17 @@ local utils = require("dataform.utils")
 
 local dataform = {}
 dataform.compiled_project_table = {}
+dataform._compile_hash = nil
 
 ---@alias DataformUserConfig table
 ---@field compile_on_save boolean? (default: true) Automatically compile Dataform project on saving a .sqlx file.
+---@field cache boolean? (default: true) Skip recompilation when project files are unchanged (in-memory check).
+---@field cache_persist boolean? (default: false) Persist cache to disk so it survives across Neovim sessions.
 
 local default_config = {
   compile_on_save = true,
+  cache = true,
+  cache_persist = false,
 }
 dataform.config = vim.deepcopy(default_config)
 
@@ -19,6 +24,69 @@ function dataform.setup(user_config)
       dataform.config[key] = value
     end
   end
+end
+
+local function compute_project_hash(cwd)
+  local uv = vim.uv or vim.loop
+  local entries = {}
+  local single_files = {
+    cwd .. "/package.json",
+    cwd .. "/dataform.json",
+    cwd .. "/workflow_settings.yaml",
+    cwd .. "/workflow_settings.yml",
+  }
+  for _, path in ipairs(single_files) do
+    local stat = uv.fs_stat(path)
+    if stat then
+      table.insert(entries, path .. ":" .. stat.mtime.sec .. ":" .. stat.size)
+    end
+  end
+  for _, dir in ipairs({ cwd .. "/includes/", cwd .. "/definitions/" }) do
+    local raw = vim.fn.glob(dir .. "**", false, false)
+    if raw ~= "" then
+      for _, path in ipairs(vim.split(raw, "\n", { plain = true })) do
+        if path ~= "" then
+          local stat = uv.fs_stat(path)
+          if stat then
+            table.insert(entries, path .. ":" .. stat.mtime.sec .. ":" .. stat.size)
+          end
+        end
+      end
+    end
+  end
+  table.sort(entries)
+  return vim.fn.sha256(table.concat(entries, "|"))
+end
+
+local function get_cache_paths(cwd)
+  local base = vim.fn.stdpath("cache") .. "/dataform.nvim/" .. vim.fn.sha256(cwd):sub(1, 16)
+  return { dir = base, hash_file = base .. "/hash", json_file = base .. "/compiled.json" }
+end
+
+local function load_from_cache(paths, current_hash)
+  local hash_file = io.open(paths.hash_file, "r")
+  if not hash_file then return nil end
+  local stored_hash = hash_file:read("*l")
+  hash_file:close()
+
+  if stored_hash ~= current_hash then return nil end
+
+  local json_file = io.open(paths.json_file, "r")
+  if not json_file then return nil end
+  local cached = json_file:read("*all")
+  json_file:close()
+
+  local ok, decoded = pcall(vim.fn.json_decode, cached)
+  if ok and type(decoded) == "table" then return decoded end
+  return nil
+end
+
+local function save_to_cache(paths, current_hash, content)
+  vim.fn.mkdir(paths.dir, "p")
+  local json_file = io.open(paths.json_file, "w")
+  if json_file then json_file:write(content); json_file:close() end
+  local hash_file = io.open(paths.hash_file, "w")
+  if hash_file then hash_file:write(current_hash); hash_file:close() end
 end
 
 function dataform.set_dataform_workdir_project_path()
@@ -71,16 +139,49 @@ end
 
 function dataform.compile()
   local command = "dataform compile"
+
+  if not dataform.config.cache then
+    local status, content = utils.os_execute_with_status(command .. " --json", true)
+    if status == 0 then
+      dataform.compiled_project_table = vim.fn.json_decode(content)
+      utils.notify("Dataform compiled successfully.", vim.log.levels.INFO)
+    else
+      local _, err = utils.os_execute_with_status(command)
+      utils.notify("Error: Dataform compile failed. \n\n" .. err, vim.log.levels.ERROR)
+    end
+    return
+  end
+
+  local cwd = vim.fn.getcwd()
+  local current_hash = compute_project_hash(cwd)
+
+  if current_hash == dataform._compile_hash then
+    utils.notify("Dataform compiled successfully (cached).", vim.log.levels.INFO)
+    return
+  end
+
+  if dataform.config.cache_persist then
+    local paths = get_cache_paths(cwd)
+    local cached = load_from_cache(paths, current_hash)
+    if cached then
+      dataform.compiled_project_table = cached
+      dataform._compile_hash = current_hash
+      utils.notify("Dataform compiled successfully (cached).", vim.log.levels.INFO)
+      return
+    end
+  end
+
   local status, content = utils.os_execute_with_status(command .. " --json", true)
   if status == 0 then
     dataform.compiled_project_table = vim.fn.json_decode(content)
+    dataform._compile_hash = current_hash
     utils.notify("Dataform compiled successfully.", vim.log.levels.INFO)
+    if dataform.config.cache_persist then
+      save_to_cache(get_cache_paths(cwd), current_hash, content)
+    end
   else
-    local _, content_error = utils.os_execute_with_status(command)
-    utils.notify(
-      "Error: Dataform compile failed. \n\n" .. content_error,
-      vim.log.levels.ERROR
-    )
+    local _, err = utils.os_execute_with_status(command)
+    utils.notify("Error: Dataform compile failed. \n\n" .. err, vim.log.levels.ERROR)
   end
 end
 
@@ -282,6 +383,16 @@ function dataform.compile_on_save()
   if dataform.config.compile_on_save then
     dataform.compile()
   end
+end
+
+function dataform.clear_cache()
+  dataform._compile_hash = nil
+  local cwd = vim.fn.getcwd()
+  local paths = get_cache_paths(cwd)
+  os.remove(paths.json_file)
+  os.remove(paths.hash_file)
+  vim.fn.delete(paths.dir, "d")
+  utils.notify("Dataform cache cleared.", vim.log.levels.INFO)
 end
 
 return dataform

--- a/plugin/dataform.vim
+++ b/plugin/dataform.vim
@@ -41,3 +41,4 @@ command! -nargs=0 DataformRunAssertions lua require('dataform').run_assertions_j
 command! -nargs=1 DataformRunTag lua require('dataform').run_tag(<f-args>)
 command! -nargs=0 DataformFindDependencies lua require('dataform').find_model_dependencies()
 command! -nargs=0 DataformFindDependents lua require('dataform').find_model_dependents()
+command! -nargs=0 DataformClearCache lua require('dataform').clear_cache()


### PR DESCRIPTION
- Adds in-memory caching of Dataform compilation results based on a hash of project file mtimes/sizes (`definitions/`, `includes/`, `package.json`, `dataform.json`, `workflow_settings.yaml`)
- Adds optional disk-based cache persistence (`cache_persist = true`) that survives across Neovim sessions, stored in `stdpath("cache")/dataform.nvim/`
- Adds a `DataformClearCache` command (and `require('dataform').clear_cache()`) to manually invalidate the cache
- Updates README with new config options, caching behavior description, and the new command

### Configuration
```lua
require("dataform").setup({
  cache = true,         -- default: true; set false to always recompile
  cache_persist = false -- default: false; set true to persist cache across sessions
})
```